### PR TITLE
Hide private talk URLs and add lock label

### DIFF
--- a/src/components/ContactMe.tsx
+++ b/src/components/ContactMe.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import TalkForm from './forms/TalkForm';
 import PodcastForm from './forms/PodcastForm';
 import InvestmentForm from './forms/InvestmentForm';
@@ -10,7 +11,22 @@ import { formClasses } from './common/FormStyles';
 type Topic = 'talk' | 'podcast' | 'investment' | 'mentorship' | 'smarthome' | 'other';
 
 const ContactMe: React.FC = () => {
+  const [searchParams] = useSearchParams();
   const [topic, setTopic] = useState<Topic>('other');
+  const [initialMessage, setInitialMessage] = useState<string>('');
+
+  useEffect(() => {
+    const topicParam = searchParams.get('topic');
+    const messageParam = searchParams.get('message');
+
+    if (topicParam && ['talk', 'podcast', 'investment', 'mentorship', 'smarthome', 'other'].includes(topicParam)) {
+      setTopic(topicParam as Topic);
+    }
+
+    if (messageParam) {
+      setInitialMessage(decodeURIComponent(messageParam));
+    }
+  }, [searchParams]);
 
   const handleTopicChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setTopic(e.target.value as Topic);
@@ -19,7 +35,7 @@ const ContactMe: React.FC = () => {
   const renderForm = () => {
     switch (topic) {
       case 'talk':
-        return <TalkForm />;
+        return <TalkForm initialMessage={initialMessage} />;
       case 'podcast':
         return <PodcastForm />;
       case 'investment':

--- a/src/components/ContactMe.tsx
+++ b/src/components/ContactMe.tsx
@@ -24,7 +24,7 @@ const ContactMe: React.FC = () => {
     }
 
     if (messageParam) {
-      setInitialMessage(decodeURIComponent(messageParam));
+      setInitialMessage(messageParam);
     }
   }, [searchParams]);
 

--- a/src/components/Talks.tsx
+++ b/src/components/Talks.tsx
@@ -41,7 +41,8 @@ const TalkCard: React.FC<{ talk: Talk }> = ({ talk }) => {
 
   const handleInviteClick = () => {
     const talkTopic = talk.tags && talk.tags.length > 0 ? talk.tags[0] : 'your talk';
-    const message = `I want a talk similar to the talk about ${talkTopic} you did in ${talk.conference}`;
+    const conferenceName = talk.conference && talk.conference.trim() ? talk.conference : 'the conference';
+    const message = `I want a talk similar to the talk about ${talkTopic} you did in ${conferenceName}`;
     navigate(`/contact?topic=talk&message=${encodeURIComponent(message)}`);
   };
 

--- a/src/components/Talks.tsx
+++ b/src/components/Talks.tsx
@@ -1,8 +1,10 @@
-import React, { useState, useEffect } from 'react';
-import { Video } from 'lucide-react';
+import React, { useState, useEffect, useRef } from 'react';
+import { Video, Lock, Info } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import Modal from './Modal';
 import ContentCard from './common/ContentCard';
+import Tooltip from './common/Tooltip';
 import { cardClasses } from './common/CardStyles';
 import ContentFilters from './common/ContentFilters';
 import { useFilterParams } from '../hooks/useFilterParams';
@@ -28,31 +30,86 @@ interface Talk {
   og_description: string;
   og_image_url: string;
   description_lang: 'Hebrew' | 'English';
+  is_private: boolean;
 }
 
 const TalkCard: React.FC<{ talk: Talk }> = ({ talk }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+  const infoIconRef = useRef<HTMLButtonElement>(null);
+  const navigate = useNavigate();
+
+  const handleInviteClick = () => {
+    const talkTopic = talk.tags && talk.tags.length > 0 ? talk.tags[0] : 'your talk';
+    const message = `I want a talk similar to the talk about ${talkTopic} you did in ${talk.conference}`;
+    navigate(`/contact?topic=talk&message=${encodeURIComponent(message)}`);
+  };
+
+  // Create links array - exclude watch and slides for private talks
+  const links = talk.is_private ? [] : [
+    ...(talk.url ? [{ url: talk.url, label: 'Watch' }] : []),
+    ...(talk.slides_url ? [{ url: talk.slides_url, label: 'Slides' }] : [])
+  ];
 
   return (
     <>
-      <ContentCard
-        title={talk.override_title || talk.og_title || talk.name}
-        description={talk.override_description || talk.og_description || talk.short_desc}
-        imageUrl={talk.og_image_url}
-        date={talk.date}
-        metadata={{
-          conference: talk.conference
-        }}
-        tags={talk.tags || []}
-        icon={<Video className="mr-1 w-4 h-4" />}
-        language={talk.lang as 'Hebrew' | 'English'}
-        descriptionLang={talk.description_lang}
-        links={[
-          ...(talk.url ? [{ url: talk.url, label: 'Watch' }] : []),
-          ...(talk.slides_url ? [{ url: talk.slides_url, label: 'Slides' }] : [])
-        ]}
-        onReadMore={() => setIsModalOpen(true)}
-      />
+      <div className="relative">
+        <ContentCard
+          title={talk.override_title || talk.og_title || talk.name}
+          description={talk.override_description || talk.og_description || talk.short_desc}
+          imageUrl={talk.og_image_url}
+          date={talk.date}
+          metadata={{
+            conference: talk.conference
+          }}
+          tags={talk.tags || []}
+          icon={<Video className="mr-1 w-4 h-4" />}
+          language={talk.lang as 'Hebrew' | 'English'}
+          descriptionLang={talk.description_lang}
+          links={links}
+          onReadMore={() => setIsModalOpen(true)}
+          privateBadge={
+            talk.is_private ? (
+              <div className="flex items-center gap-2 mt-2">
+                <div className="inline-flex items-center gap-1 px-3 py-1 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 rounded-full text-sm font-medium">
+                  <Lock size={14} />
+                  <span>Private</span>
+                </div>
+                <button
+                  ref={infoIconRef}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setIsTooltipOpen(!isTooltipOpen);
+                  }}
+                  className="inline-flex items-center justify-center w-6 h-6 rounded-full bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400 hover:bg-blue-200 dark:hover:bg-blue-800 transition-colors"
+                  aria-label="More information about private talk"
+                >
+                  <Info size={14} />
+                </button>
+                {isTooltipOpen && (
+                  <Tooltip
+                    isOpen={isTooltipOpen}
+                    onClose={() => setIsTooltipOpen(false)}
+                    anchorRef={infoIconRef}
+                  >
+                    <div className="space-y-3">
+                      <p className="text-sm text-gray-700 dark:text-gray-300">
+                        This is a private talk
+                      </p>
+                      <button
+                        onClick={handleInviteClick}
+                        className="w-full px-4 py-2 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg hover:from-blue-700 hover:to-purple-700 transition-all duration-300 text-sm font-medium"
+                      >
+                        Invite for your organization
+                      </button>
+                    </div>
+                  </Tooltip>
+                )}
+              </div>
+            ) : undefined
+          }
+        />
+      </div>
       <Modal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}

--- a/src/components/common/ContentCard.tsx
+++ b/src/components/common/ContentCard.tsx
@@ -21,6 +21,7 @@ interface ContentCardProps {
   language: 'Hebrew' | 'English';
   descriptionLang?: 'Hebrew' | 'English';
   onReadMore?: () => void;
+  privateBadge?: React.ReactNode;
 }
 
 const ContentCard: React.FC<ContentCardProps> = ({
@@ -34,7 +35,8 @@ const ContentCard: React.FC<ContentCardProps> = ({
   links,
   language,
   descriptionLang = 'English',
-  onReadMore
+  onReadMore,
+  privateBadge
 }) => {
   const languageFlag = language === 'Hebrew' ? '🇮🇱' : '🇺🇸';
   const isDescriptionRTL = descriptionLang === 'Hebrew';
@@ -136,6 +138,11 @@ const ContentCard: React.FC<ContentCardProps> = ({
                   </a>
                 ))}
               </div>
+
+              {/* Private Badge */}
+              {privateBadge && (
+                <div>{privateBadge}</div>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -23,12 +23,20 @@ const Tooltip: React.FC<TooltipProps> = ({ isOpen, onClose, children, anchorRef 
       }
     };
 
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
     if (isOpen) {
       document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('keydown', handleKeyDown);
     }
 
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
     };
   }, [isOpen, onClose, anchorRef]);
 

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -1,0 +1,60 @@
+import React, { useRef, useEffect } from 'react';
+import { X } from 'lucide-react';
+
+interface TooltipProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+  anchorRef: React.RefObject<HTMLElement>;
+}
+
+const Tooltip: React.FC<TooltipProps> = ({ isOpen, onClose, children, anchorRef }) => {
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        tooltipRef.current &&
+        !tooltipRef.current.contains(event.target as Node) &&
+        anchorRef.current &&
+        !anchorRef.current.contains(event.target as Node)
+      ) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isOpen, onClose, anchorRef]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={tooltipRef}
+      className="absolute z-50 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-4 min-w-[280px] max-w-[320px]"
+      style={{
+        top: '100%',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        marginTop: '8px'
+      }}
+    >
+      <button
+        onClick={onClose}
+        className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+        aria-label="Close tooltip"
+      >
+        <X size={16} />
+      </button>
+      {children}
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/src/components/forms/TalkForm.tsx
+++ b/src/components/forms/TalkForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { submitContactForm } from '../../lib/submit-contact-form';
 import Popup from '../common/Popup';
 import { formClasses, getInputClassName } from '../common/FormStyles';
@@ -16,7 +16,11 @@ interface FormData {
   paid: boolean;
 }
 
-const TalkForm: React.FC = () => {
+interface TalkFormProps {
+  initialMessage?: string;
+}
+
+const TalkForm: React.FC<TalkFormProps> = ({ initialMessage = '' }) => {
   const [formData, setFormData] = useState<FormData>({
     topic: 'talk',
     name: '',
@@ -26,7 +30,7 @@ const TalkForm: React.FC = () => {
     event_format: '',
     audience_size: '',
     event_topic: '',
-    message: '',
+    message: initialMessage,
     paid: false,
   });
 
@@ -35,6 +39,12 @@ const TalkForm: React.FC = () => {
     message: '',
     type: 'success' as 'success' | 'error'
   });
+
+  useEffect(() => {
+    if (initialMessage) {
+      setFormData(prevState => ({ ...prevState, message: initialMessage }));
+    }
+  }, [initialMessage]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target;

--- a/src/components/forms/TalkForm.tsx
+++ b/src/components/forms/TalkForm.tsx
@@ -40,12 +40,6 @@ const TalkForm: React.FC<TalkFormProps> = ({ initialMessage = '' }) => {
     type: 'success' as 'success' | 'error'
   });
 
-  useEffect(() => {
-    if (initialMessage) {
-      setFormData(prevState => ({ ...prevState, message: initialMessage }));
-    }
-  }, [initialMessage]);
-
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
     setFormData(prevState => ({ ...prevState, [name]: value }));


### PR DESCRIPTION

- Add is_private field to Talk interface
- Create Tooltip component for interactive tooltips
- Hide watch/slides URLs for private talks
- Add private badge with lock icon to private talk cards
- Add info icon with tooltip showing "This is a private talk"
- Add "Invite for your organization" button in tooltip
- Navigate to contact page with pre-filled talk invitation message
- Update ContactMe to support URL parameters (topic and message)
- Update TalkForm to accept and use pre-filled message
- Keep displaying image, date, topics, conference, and description for private talks