### PR TITLE
Add Communities tab with dedicated page and link from About section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import Header from './components/Header';
 import AboutMe from './components/AboutMe';
 import Talks from './components/Talks';
 import Podcasts from './components/Podcasts';
+import Communities from './components/Communities';
 import Blog from './components/Blog';
 import ContactMe from './components/ContactMe';
 import Footer from './components/Footer';
@@ -27,6 +28,7 @@ const AppContent = () => {
           <Route path="/about" element={<AboutMe />} />
           <Route path="/talks" element={<Talks />} />
           <Route path="/podcasts" element={<Podcasts />} />
+          <Route path="/communities" element={<Communities />} />
           <Route path="/blog" element={<Blog />} />
           <Route path="/contact" element={<ContactMe />} />
           <Route path="*" element={<Navigate to="/about" replace />} />

--- a/src/components/AboutMe.tsx
+++ b/src/components/AboutMe.tsx
@@ -299,6 +299,36 @@ const AboutMe: React.FC = () => {
         </button>
         </div>
       </div>
+
+      {/* Communities CTA Section */}
+      <div className="container mx-auto px-4 py-20">
+        <div className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-blue-600 to-purple-600 p-10 md:p-16 text-center shadow-2xl">
+          <div className="absolute inset-0 overflow-hidden">
+            <div className="absolute -top-20 -right-20 w-64 h-64 bg-white/10 rounded-full blur-3xl"></div>
+            <div className="absolute -bottom-20 -left-20 w-64 h-64 bg-white/10 rounded-full blur-3xl"></div>
+          </div>
+          <div className="relative">
+            <span className="inline-flex p-4 rounded-2xl bg-white/15 text-white mb-6">
+              <Users className="w-8 h-8" />
+            </span>
+            <h2 className="text-3xl md:text-4xl font-bold text-white mb-4">
+              Join My Communities
+            </h2>
+            <p className="text-lg text-blue-50 leading-relaxed max-w-2xl mx-auto mb-8">
+              I build and lead several active AI and automation communities — MCP Israel, n8n Israel,
+              the AI Transformation Guild &amp; AI Leaders, and The Agentcy. Discover what each one is
+              about and how you can join.
+            </p>
+            <Link
+              to="/communities"
+              className="inline-flex items-center gap-2 px-8 py-4 bg-white text-blue-600 font-semibold rounded-xl hover:bg-blue-50 transform hover:scale-105 transition-all duration-200 shadow-lg"
+            >
+              Explore My Communities
+              <ArrowRight className="w-5 h-5" />
+            </Link>
+          </div>
+        </div>
+      </div>
     </section>
   );
 };

--- a/src/components/AboutMe.tsx
+++ b/src/components/AboutMe.tsx
@@ -80,6 +80,7 @@ const AboutMe: React.FC = () => {
     autoplay: true,
     autoplaySpeed: 5000,
     arrows: false,
+    adaptiveHeight: true,
   };
 
   return (
@@ -279,22 +280,21 @@ const AboutMe: React.FC = () => {
           .slick-dots li button:before {
             font-size: 8px;
           }
-          /* Let each slide grow to its content (uniform via flex) so taller
-             slides, like the Community Leader card with its button, are never
-             clipped by slick's fixed list height — especially on mobile. */
-          .slick-list {
-            height: auto !important;
-          }
+          /* slick's default ".slick-slide { height: 100% }" forces every slide
+             to the container's fixed height, which clips taller slides (e.g. the
+             Community Leader card with its button) on mobile. Let each slide size
+             to its own content and use a flex track to avoid float misalignment;
+             adaptiveHeight then fits the viewport to the active slide so the dots
+             always sit right beneath it. */
           .slick-track {
             display: flex !important;
-            align-items: stretch !important;
-            height: auto !important;
+            align-items: flex-start !important;
           }
           .slick-slide {
             height: auto !important;
           }
           .slick-slide > div {
-            height: 100%;
+            height: auto !important;
           }
         `}</style>
         

--- a/src/components/AboutMe.tsx
+++ b/src/components/AboutMe.tsx
@@ -1,16 +1,25 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Slider from 'react-slick';
 import {
-  Code, DollarSign, Mic, Users, Home, PenTool, MessageSquare, ChevronLeft, ChevronRight
+  Code, DollarSign, Mic, Users, Home, PenTool, MessageSquare, ChevronLeft, ChevronRight, ArrowRight
 } from 'lucide-react';
 import { cardClasses } from './common/CardStyles';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 
+interface Section {
+  title: string;
+  icon: React.ReactNode;
+  content: string;
+  image: string;
+  link?: { to: string; label: string };
+}
+
 const AboutMe: React.FC = () => {
   const sliderRef = React.useRef<Slider>(null);
 
-  const sections = [
+  const sections: Section[] = [
     {
       title: 'Dev and Open Source Leader',
       icon: <Code className="w-6 h-6 mr-2" />,
@@ -20,8 +29,9 @@ const AboutMe: React.FC = () => {
     {
       title: 'Community Leader',
       icon: <Users className="w-6 h-6 mr-2" />,
-      content: "I lead two active and fast-growing communities: MCP Israel and n8n Israel. These communities bring together developers, enthusiasts, and professionals to share knowledge, collaborate on projects, and drive innovation in their respective domains. Building and nurturing these communities allows me to foster learning and growth while connecting like-minded individuals.",
+      content: "I build and lead several active and fast-growing communities, including MCP Israel, n8n Israel, the AI Transformation Guild & AI Leaders, and The Agentcy. These communities bring together developers, enthusiasts, and professionals to share knowledge, collaborate on projects, and drive innovation in AI and automation. Building and nurturing these communities allows me to foster learning and growth while connecting like-minded individuals.",
       image: 'https://res.cloudinary.com/dzc7cp7jh/image/upload/f_auto,q_auto/v1754834694/combined-logos_taaqne.png',
+      link: { to: '/communities', label: 'Explore my communities' },
     },
     {
       title: 'Angel Investor',
@@ -132,7 +142,7 @@ const AboutMe: React.FC = () => {
                   <div className="text-sm text-gray-600 dark:text-gray-400">Projects</div>
                 </div>
                 <div className="text-center">
-                  <div className="text-2xl md:text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">2</div>
+                  <div className="text-2xl md:text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">5</div>
                   <div className="text-sm text-gray-600 dark:text-gray-400">Communities</div>
                 </div>
               </div>
@@ -240,6 +250,15 @@ const AboutMe: React.FC = () => {
                         <p className="text-sm md:text-base lg:text-xl text-gray-600 dark:text-gray-300 leading-relaxed">
                           {section.content}
                         </p>
+                        {section.link && (
+                          <Link
+                            to={section.link.to}
+                            className="mt-4 inline-flex items-center gap-2 text-blue-600 dark:text-blue-400 font-semibold hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+                          >
+                            {section.link.label}
+                            <ArrowRight className="w-4 h-4" />
+                          </Link>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/src/components/AboutMe.tsx
+++ b/src/components/AboutMe.tsx
@@ -141,10 +141,13 @@ const AboutMe: React.FC = () => {
                   <div className="text-2xl md:text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">100+</div>
                   <div className="text-sm text-gray-600 dark:text-gray-400">Projects</div>
                 </div>
-                <div className="text-center">
+                <Link to="/communities" className="text-center group cursor-pointer">
                   <div className="text-2xl md:text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">5</div>
-                  <div className="text-sm text-gray-600 dark:text-gray-400">Communities</div>
-                </div>
+                  <div className="text-sm text-gray-600 dark:text-gray-400 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors inline-flex items-center gap-1">
+                    Communities
+                    <ArrowRight className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+                  </div>
+                </Link>
               </div>
             </div>
 
@@ -253,7 +256,7 @@ const AboutMe: React.FC = () => {
                         {section.link && (
                           <Link
                             to={section.link.to}
-                            className="mt-4 inline-flex items-center gap-2 text-blue-600 dark:text-blue-400 font-semibold hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+                            className="mt-6 inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 text-white font-semibold rounded-xl hover:from-blue-700 hover:to-purple-700 transform hover:scale-105 transition-all duration-200 shadow-md hover:shadow-lg w-fit"
                           >
                             {section.link.label}
                             <ArrowRight className="w-4 h-4" />

--- a/src/components/AboutMe.tsx
+++ b/src/components/AboutMe.tsx
@@ -240,7 +240,7 @@ const AboutMe: React.FC = () => {
                   
                   {/* Content Section */}
                   <div className="md:w-1/2">
-                    <div className="flex flex-col gap-4 h-[500px] md:justify-center">
+                    <div className="flex flex-col gap-4 md:h-[500px] md:justify-center">
                       <div className="flex flex-col gap-3">
                         <span className="inline-flex w-fit p-2 md:p-3 rounded-lg bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-300">
                           {section.icon}

--- a/src/components/AboutMe.tsx
+++ b/src/components/AboutMe.tsx
@@ -279,6 +279,23 @@ const AboutMe: React.FC = () => {
           .slick-dots li button:before {
             font-size: 8px;
           }
+          /* Let each slide grow to its content (uniform via flex) so taller
+             slides, like the Community Leader card with its button, are never
+             clipped by slick's fixed list height — especially on mobile. */
+          .slick-list {
+            height: auto !important;
+          }
+          .slick-track {
+            display: flex !important;
+            align-items: stretch !important;
+            height: auto !important;
+          }
+          .slick-slide {
+            height: auto !important;
+          }
+          .slick-slide > div {
+            height: 100%;
+          }
         `}</style>
         
         {/* Navigation buttons */}

--- a/src/components/Communities.tsx
+++ b/src/components/Communities.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { Users, Workflow, Building2, Bot, ArrowRight, Sparkles } from 'lucide-react';
+
+interface Community {
+  name: string;
+  tagline: string;
+  icon: React.ReactNode;
+  description: string;
+  highlights: string[];
+  members?: string;
+  registrationUrl: string;
+}
+
+const communities: Community[] = [
+  {
+    name: 'MCP Israel',
+    tagline: 'A general AI community for engineers and builders',
+    icon: <Users className="w-7 h-7" />,
+    description:
+      "A general AI community with more than 3,000 members, mostly engineers. It started around MCP (Model Context Protocol) but has grown into a broad AI community. A place for news, help, info, articles, and meetups.",
+    highlights: ['News & trends', 'Hands-on help', 'Articles & resources', 'Meetups'],
+    members: '3,000+ members',
+    registrationUrl: 'https://gilad.click/mcp-israel-registration',
+  },
+  {
+    name: 'n8n Israel',
+    tagline: 'For automators, builders, and integration experts',
+    icon: <Workflow className="w-7 h-7" />,
+    description:
+      "Whether you're building automations, working with n8n, or just curious about how to connect services smartly, this is the right place. Not sure how to get started? Ask and get help from the community. Built an interesting workflow? Share it and get feedback. Discovered a cool integration or a useful trick? Let others enjoy it too. Here you'll find guides, tips, and resources, plus discussions, news, trends, and questions about nodes, integrations, and self-hosting. Join a community of creators, automators, and integration experts and grow together.",
+    highlights: ['Workflows & feedback', 'Integrations', 'Self-hosting', 'Guides & tips'],
+    registrationUrl: 'https://gilad.click/n8n-israel-registration',
+  },
+  {
+    name: 'AI Transformation Guild & AI Leaders',
+    tagline: 'For professionals driving AI adoption in organizations',
+    icon: <Building2 className="w-7 h-7" />,
+    description:
+      "A community for professionals leading the implementation, adoption, and transformation of AI within organizations. It's designed for those for whom this is part of their role: innovation managers, AI Leads, Product and Data people, and key stakeholders advancing real AI applications across the business. The community is a place to share hands-on experience from the field, get advice, discuss challenges, learn from others' approaches, and discover tools and methods that truly work. The focus is on real organizational work, not games or experiments, but implementation that creates real value.",
+    highlights: ['Real-world experience', 'Org adoption', 'Advice & challenges', 'Tools that work'],
+    registrationUrl: 'https://gilad.click/ai-transformation-guild-registration',
+  },
+  {
+    name: 'The Agentcy',
+    tagline: 'The Israeli HQ for agentic teams and orchestration',
+    icon: <Bot className="w-7 h-7" />,
+    description:
+      "Welcome to The Agentcy, the Israeli headquarters for agentic teams, orchestration, and running companies powered by AI agents. We're here to turn AI from a chatbot into a Synthetic Workforce. The community focuses on building, managing, and optimizing Multi-Agent Systems, from deep technical tooling (like Paperclip and LangGraph) to leading orchestration and management products (Overcut, Agentopology). On the agenda: Field Reports (case studies and architectures of agent teams), Agentic Workflows (how to make agents actually work together), New Recruits (the newest tools and agents on the market), and the Situation Room (real-time consultations and problem-solving).",
+    highlights: ['Multi-Agent Systems', 'Orchestration', 'Field reports', 'Live problem-solving'],
+    registrationUrl: 'https://gilad.click/the-agentcy-registration',
+  },
+];
+
+const Communities: React.FC = () => {
+  return (
+    <section className="relative">
+      {/* Hero Section */}
+      <div className="relative overflow-hidden bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 rounded-3xl">
+        <div className="absolute inset-0 overflow-hidden">
+          <div className="absolute -top-40 -right-32 w-80 h-80 bg-gradient-to-br from-blue-400/20 to-purple-600/20 rounded-full blur-3xl animate-pulse"></div>
+          <div className="absolute bottom-0 -left-32 w-80 h-80 bg-gradient-to-br from-purple-400/20 to-pink-600/20 rounded-full blur-3xl animate-pulse delay-1000"></div>
+        </div>
+
+        <div className="relative container mx-auto px-4 py-16 text-center">
+          <span className="inline-flex items-center gap-2 px-4 py-2 mb-6 rounded-full bg-blue-100 dark:bg-blue-900/50 text-blue-600 dark:text-blue-300 text-sm font-medium">
+            <Sparkles className="w-4 h-4" />
+            Community Leader
+          </span>
+          <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6">
+            <span className="bg-gradient-to-r from-gray-900 via-blue-800 to-purple-800 dark:from-white dark:via-blue-200 dark:to-purple-200 bg-clip-text text-transparent">
+              My Communities
+            </span>
+          </h1>
+          <p className="text-lg md:text-xl text-gray-600 dark:text-gray-300 leading-relaxed max-w-3xl mx-auto">
+            I build and lead active, fast-growing communities that bring together developers,
+            enthusiasts, and professionals to share knowledge, collaborate, and drive innovation in
+            AI and automation. Here's what each one is about, and how you can join.
+          </p>
+        </div>
+      </div>
+
+      {/* Communities Grid */}
+      <div className="container mx-auto px-4 py-16">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          {communities.map((community) => (
+            <div
+              key={community.name}
+              className="group flex flex-col bg-white/60 dark:bg-gray-800/50 backdrop-blur-lg rounded-2xl border border-gray-100 dark:border-gray-700 p-8 hover:shadow-xl transition-all duration-300 hover:-translate-y-1"
+            >
+              <div className="flex items-start gap-4 mb-4">
+                <span className="inline-flex shrink-0 p-3 rounded-xl bg-gradient-to-br from-blue-600 to-purple-600 text-white shadow-md">
+                  {community.icon}
+                </span>
+                <div>
+                  <h2 className="text-2xl font-bold text-gray-900 dark:text-white group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                    {community.name}
+                  </h2>
+                  <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                    {community.tagline}
+                  </p>
+                </div>
+              </div>
+
+              {community.members && (
+                <div className="mb-4">
+                  <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300 text-sm font-medium">
+                    <Users className="w-4 h-4" />
+                    {community.members}
+                  </span>
+                </div>
+              )}
+
+              <p className="text-gray-600 dark:text-gray-300 leading-relaxed mb-6 flex-grow">
+                {community.description}
+              </p>
+
+              <div className="flex flex-wrap gap-2 mb-6">
+                {community.highlights.map((highlight) => (
+                  <span
+                    key={highlight}
+                    className="px-3 py-1 text-sm font-medium rounded-full bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-300"
+                  >
+                    {highlight}
+                  </span>
+                ))}
+              </div>
+
+              <a
+                href={community.registrationUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center gap-2 w-full sm:w-auto px-6 py-3 bg-gradient-to-r from-blue-600 to-purple-600 text-white font-semibold rounded-xl hover:from-blue-700 hover:to-purple-700 transform hover:scale-105 transition-all duration-200 shadow-md hover:shadow-lg"
+              >
+                Join {community.name}
+                <ArrowRight className="w-4 h-4" />
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Communities;

--- a/src/components/Communities.tsx
+++ b/src/components/Communities.tsx
@@ -29,6 +29,7 @@ const communities: Community[] = [
     description:
       "Whether you're building automations, working with n8n, or just curious about how to connect services smartly, this is the right place. Not sure how to get started? Ask and get help from the community. Built an interesting workflow? Share it and get feedback. Discovered a cool integration or a useful trick? Let others enjoy it too. Here you'll find guides, tips, and resources, plus discussions, news, trends, and questions about nodes, integrations, and self-hosting. Join a community of creators, automators, and integration experts and grow together.",
     highlights: ['Workflows & feedback', 'Integrations', 'Self-hosting', 'Guides & tips'],
+    members: '3,000+ members',
     registrationUrl: 'https://gilad.click/n8n-israel-registration',
   },
   {
@@ -38,6 +39,7 @@ const communities: Community[] = [
     description:
       "A community for professionals leading the implementation, adoption, and transformation of AI within organizations. It's designed for those for whom this is part of their role: innovation managers, AI Leads, Product and Data people, and key stakeholders advancing real AI applications across the business. The community is a place to share hands-on experience from the field, get advice, discuss challenges, learn from others' approaches, and discover tools and methods that truly work. The focus is on real organizational work, not games or experiments, but implementation that creates real value.",
     highlights: ['Real-world experience', 'Org adoption', 'Advice & challenges', 'Tools that work'],
+    members: '500+ members',
     registrationUrl: 'https://gilad.click/ai-transformation-guild-registration',
   },
   {
@@ -47,6 +49,7 @@ const communities: Community[] = [
     description:
       "Welcome to The Agentcy, the Israeli headquarters for agentic teams, orchestration, and running companies powered by AI agents. We're here to turn AI from a chatbot into a Synthetic Workforce. The community focuses on building, managing, and optimizing Multi-Agent Systems, from deep technical tooling (like Paperclip and LangGraph) to leading orchestration and management products (Overcut, Agentopology). On the agenda: Field Reports (case studies and architectures of agent teams), Agentic Workflows (how to make agents actually work together), New Recruits (the newest tools and agents on the market), and the Situation Room (real-time consultations and problem-solving).",
     highlights: ['Multi-Agent Systems', 'Orchestration', 'Field reports', 'Live problem-solving'],
+    members: '600+ members',
     registrationUrl: 'https://gilad.click/the-agentcy-registration',
   },
 ];

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -45,7 +45,7 @@ const Header: React.FC<HeaderProps> = ({ activeTab, setActiveTab }) => {
           {/* Desktop Navigation */}
           <nav className="hidden md:flex flex-grow justify-center">
             <ul className="flex space-x-1">
-              {['about', 'talks', 'podcasts', 'blog', 'contact'].map((tab) => (
+              {['about', 'talks', 'podcasts', 'communities', 'blog', 'contact'].map((tab) => (
                 <li key={tab}>
                   <button
                     onClick={() => handleTabClick(tab)}
@@ -78,7 +78,7 @@ const Header: React.FC<HeaderProps> = ({ activeTab, setActiveTab }) => {
         {isMenuOpen && (
           <div className="md:hidden py-4">
             <ul className="flex flex-col space-y-2">
-              {['about', 'talks', 'podcasts', 'blog', 'contact'].map((tab) => (
+              {['about', 'talks', 'podcasts', 'communities', 'blog', 'contact'].map((tab) => (
                 <li key={tab}>
                   <button
                     onClick={() => handleTabClick(tab)}


### PR DESCRIPTION
- Add Communities page describing MCP Israel, n8n Israel, AI Transformation
  Guild & AI Leaders, and The Agentcy, each with a join link
- Add /communities route and nav tab (desktop + mobile)
- Link to the Communities page from the Community Leader card on About
- Update communities count stat on the About hero