### PR TITLE
Add dark mode support to Popup component

### DIFF
--- a/src/components/common/Popup.tsx
+++ b/src/components/common/Popup.tsx
@@ -10,9 +10,15 @@ interface PopupProps {
 const Popup: React.FC<PopupProps> = ({ isOpen, onClose, message, type }) => {
   if (!isOpen) return null;
 
-  const bgColor = type === 'success' ? 'bg-green-100' : 'bg-red-100';
-  const textColor = type === 'success' ? 'text-green-800' : 'text-red-800';
-  const iconColor = type === 'success' ? 'text-green-500' : 'text-red-500';
+  const bgColor = type === 'success'
+    ? 'bg-green-100 dark:bg-green-900 border border-green-200 dark:border-green-700'
+    : 'bg-red-100 dark:bg-red-900 border border-red-200 dark:border-red-700';
+  const textColor = type === 'success'
+    ? 'text-green-800 dark:text-green-100'
+    : 'text-red-800 dark:text-red-100';
+  const iconColor = type === 'success'
+    ? 'text-green-500 dark:text-green-300'
+    : 'text-red-500 dark:text-red-300';
 
   return (
     <div className="fixed inset-0 flex items-center justify-center z-50 bg-black bg-opacity-50">
@@ -20,7 +26,7 @@ const Popup: React.FC<PopupProps> = ({ isOpen, onClose, message, type }) => {
         <button
           onClick={onClose}
           aria-label="Close"
-          className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+          className="absolute top-2 right-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
         >
           <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
             <path


### PR DESCRIPTION
## Summary
Enhanced the Popup component with comprehensive dark mode styling to ensure consistent appearance across light and dark themes.

## Key Changes
- Updated background colors with dark mode variants (`dark:bg-green-900`, `dark:bg-red-900`)
- Added borders to popup containers for better visual definition in both themes
- Updated text colors with dark mode alternatives (`dark:text-green-100`, `dark:text-red-100`)
- Updated icon colors with dark mode variants (`dark:text-green-300`, `dark:text-red-300`)
- Enhanced close button styling with dark mode hover states (`dark:text-gray-400`, `dark:hover:text-gray-200`)

## Implementation Details
All color changes follow Tailwind CSS dark mode conventions using the `dark:` prefix, ensuring the component automatically adapts to the user's system theme preference or manual theme selection.

https://claude.ai/code/session_0179tSAPCV3KcgUcXVe1b6er