### PR TITLE
fix: show new talks/blog/podcasts rows immediately (drop 1h ISR cache)

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -7,7 +7,8 @@ export const metadata: Metadata = {
   description: 'Articles and blog posts written by Gilad Shoham.',
 };
 
-export const revalidate = 3600;
+// Render on every request so newly-added Supabase rows appear immediately.
+export const dynamic = 'force-dynamic';
 
 export default async function BlogPage() {
   const posts = await fetchBlogPosts();

--- a/src/app/podcasts/page.tsx
+++ b/src/app/podcasts/page.tsx
@@ -7,7 +7,8 @@ export const metadata: Metadata = {
   description: 'Podcast appearances and episodes featuring Gilad Shoham.',
 };
 
-export const revalidate = 3600;
+// Render on every request so newly-added Supabase rows appear immediately.
+export const dynamic = 'force-dynamic';
 
 export default async function PodcastsPage() {
   const podcasts = await fetchPodcasts();

--- a/src/app/talks/page.tsx
+++ b/src/app/talks/page.tsx
@@ -8,8 +8,10 @@ export const metadata: Metadata = {
     'Talks by Gilad Shoham at meetups and international conferences on web, dev tools, architecture, JavaScript, development processes, smart homes, and more.',
 };
 
-// Re-generate the page at most once an hour (ISR) for fast, SEO-friendly pages.
-export const revalidate = 3600;
+// Render on every request so newly-added Supabase rows appear immediately.
+// The page is still server-rendered (content in the HTML for SEO); the only
+// cost is one fast DB query per request.
+export const dynamic = 'force-dynamic';
 
 export default async function TalksPage() {
   const talks = await fetchTalks();


### PR DESCRIPTION
## Problem
New rows added to Supabase (e.g. the "Claude Code Workshop - Lightico" talk) weren't appearing on the live site. After the Next.js migration, the `talks`, `blog`, and `podcasts` pages used ISR (`revalidate = 3600`), so they only refreshed once an hour, and stale-while-revalidate meant the first visit after expiry still served stale content.

## Fix
Replace `revalidate = 3600` with `export const dynamic = 'force-dynamic'` on the three pages. They're now server-rendered on demand, so newly-added rows show up immediately. Pages stay SSR'd (content in the HTML, SEO unaffected); the only cost is one fast DB query per request. These flags are data-source-agnostic and survive the upcoming InstantDB migration.

Verified with `pnpm build`: the three routes now report `ƒ (Dynamic) server-rendered on demand`.